### PR TITLE
fix: entities creation by order to avoid error on relationed tables

### DIFF
--- a/backend-ts/src/core/dbconfig/order.ts
+++ b/backend-ts/src/core/dbconfig/order.ts
@@ -1,0 +1,6 @@
+export const entityOrder = [
+    'user.entity.ts',
+    'profile.entity.ts',
+    'profileViews.entity.ts',
+    // Add other entities in the order they should be loaded
+];


### PR DESCRIPTION
This pull request includes changes to improve the loading sequence of entities in the database configuration. The changes ensure that entities are loaded in a specific order, which can be crucial for maintaining data integrity and dependencies.

### Improvements to entity loading:

* [`backend-ts/src/core/dbconfig/load.ts`](diffhunk://#diff-836bf4e9dbb0198b825e79df0bbec7fac0112af2ae1249cdf70f0c965f0f50deL2-R31): Refactored the code to use `path.join` for better path handling and added logic to load entities in a specified order using the `entityOrder` array.
* [`backend-ts/src/core/dbconfig/order.ts`](diffhunk://#diff-de29a5a18c40b1f43a65467025803120c38b21dccbf366771aaac4ce46d17c0eR1-R6): Introduced the `entityOrder` array to define the order in which entities should be loaded.