### PR TITLE
add: profileviews table and fix table creation with uppercase names

### DIFF
--- a/backend-ts/src/modules/user/entities/profileViews.entity.ts
+++ b/backend-ts/src/modules/user/entities/profileViews.entity.ts
@@ -1,0 +1,33 @@
+import { createModel, createType, foreignKey } from "../../../shared/models/entity";
+
+const columns = {
+    id: 'SERIAL PRIMARY KEY',
+    viewerId: 'UUID NOT NULL',
+    viewedProfileId: 'UUID NOT NULL',
+    viewedAt: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP',
+};
+
+
+
+let model = null;
+(async () => {
+    const foreignKey: foreignKey[] = [
+        {
+            column: 'viewerId',
+            refTable: 'users',
+            refColumn: 'id',
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE'
+        },
+        {
+            column: 'viewedProfileId',
+            refTable: 'users',
+            refColumn: 'id',
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE'
+        }
+    ];
+    model = createModel({ tableName: 'profileViews', columns, foreignKey })
+    // console.log(model.createTableQuery());
+    model.syncTable();
+})();


### PR DESCRIPTION
This pull request introduces a new entity for tracking profile views in the `backend-ts` module and includes several enhancements to the shared entity model functionality. The most important changes include the creation of the `profileViews` entity, logging table creation events, and ensuring table names are consistently in lowercase.

New entity creation:

* [`backend-ts/src/modules/user/entities/profileViews.entity.ts`](diffhunk://#diff-f8d1499d822598ebeeeec0c0c816ae34ad70ddbb9178d8a99511349d1e60dc73R1-R33): Added the `profileViews` entity with columns for `id`, `viewerId`, `viewedProfileId`, and `viewedAt`, and set up foreign key relationships to the `users` table. This entity tracks when a user views another user's profile.

Enhancements to shared entity model:

* [`backend-ts/src/shared/models/entity.ts`](diffhunk://#diff-c404a4aa4755cff4d6b16acfab5649efc24b81578540d15fa7eafd6cf7063a08L41-R41): Added logging for table creation events to help with debugging and monitoring.
* [`backend-ts/src/shared/models/entity.ts`](diffhunk://#diff-c404a4aa4755cff4d6b16acfab5649efc24b81578540d15fa7eafd6cf7063a08R68-L69): Modified the table name parameter in SQL queries to be consistently in lowercase to avoid case sensitivity issues.
* [`backend-ts/src/shared/models/entity.ts`](diffhunk://#diff-c404a4aa4755cff4d6b16acfab5649efc24b81578540d15fa7eafd6cf7063a08R86): Added a missing line break for better readability and consistency in the code.